### PR TITLE
Add a check for post author to JSON+LD output.

### DIFF
--- a/inc/json-ld-namespace.php
+++ b/inc/json-ld-namespace.php
@@ -92,9 +92,14 @@ function singular( array $meta, array $context ) : array {
 	$meta['datePublished'] = get_the_date( 'c', $context['object'] );
 	$meta['dateModified'] = get_the_modified_date( 'c', $context['object'] );
 	$meta['mainEntityOfPage'] = get_the_permalink( $context['object_id'] );
-	$meta['author'] = [
-		get_person( get_user_by( 'id', $context['object']->post_author ) )
-	];
+	
+	// Post author is only set for post types that support it.
+	if ( post_type_supports( $context['object']->post_type, 'author' ) && isset( $context['object']->post_author ) ) {
+		$meta['author'] = [
+			get_person( get_user_by( 'id', $context['object']->post_author ) )
+		];
+	}
+	
 	$meta['keywords'] = [];
 	foreach ( get_post_taxonomies( $context['object'] ) as $taxonomy ) {
 		if ( $context['taxonomies'][ $taxonomy ] ?? false ) {

--- a/inc/json-ld-namespace.php
+++ b/inc/json-ld-namespace.php
@@ -94,7 +94,7 @@ function singular( array $meta, array $context ) : array {
 	$meta['mainEntityOfPage'] = get_the_permalink( $context['object_id'] );
 	
 	// Post author is only set for post types that support it.
-	if ( post_type_supports( $context['object']->post_type, 'author' ) && isset( $context['object']->post_author ) ) {
+	if ( post_type_supports( $context['object']->post_type, 'author' ) && ! empty( $context['object']->post_author ) ) {
 		$meta['author'] = [
 			get_person( get_user_by( 'id', $context['object']->post_author ) )
 		];


### PR DESCRIPTION
Gutenberg requires `author` to be defined under `supports` for it to save the post_author in the database - classic editor doesn't have this issue. This puts a condition to check to see if the `post_author` exists - https://github.com/humanmade/meta-tags/blob/master/inc/json-ld-namespace.php#L95

Fixes #6 