### PR TITLE
Prevent fatals when accessing non-existant author pages

### DIFF
--- a/inc/json-ld-namespace.php
+++ b/inc/json-ld-namespace.php
@@ -92,7 +92,7 @@ function singular( array $meta, array $context ) : array {
 	$meta['datePublished'] = get_the_date( 'c', $context['object'] );
 	$meta['dateModified'] = get_the_modified_date( 'c', $context['object'] );
 	$meta['mainEntityOfPage'] = get_the_permalink( $context['object_id'] );
-	
+
 	// Post author is only set for post types that support it.
 	if ( post_type_supports( $context['object']->post_type, 'author' ) && ! empty( $context['object']->post_author ) ) {
 		$author = get_user_by( 'id', $context['object']->post_author );
@@ -103,7 +103,7 @@ function singular( array $meta, array $context ) : array {
 			];
 		}
 	}
-	
+
 	$meta['keywords'] = [];
 	foreach ( get_post_taxonomies( $context['object'] ) as $taxonomy ) {
 		if ( $context['taxonomies'][ $taxonomy ] ?? false ) {
@@ -146,7 +146,10 @@ function archive( array $meta, array $context ) : array {
  * @return array
  */
 function author( array $meta, array $context ) : array {
-	$meta = get_person( $context['object'] );
+	if ( ! empty( $context['object'] ) ) {
+		$meta = get_person( $context['object'] );
+	}
+
 	return $meta;
 }
 

--- a/inc/opengraph-namespace.php
+++ b/inc/opengraph-namespace.php
@@ -102,8 +102,11 @@ function singular( array $meta, array $context ) : array {
 function author( array $meta, array $context ) : array {
 	$meta = get_default_meta( $meta, $context );
 	$meta['type'] = 'profile';
-	$meta['profile:first_name'] = $context['object']->get( 'first_name' );
-	$meta['profile:last_name'] = $context['object']->get( 'last_name' );
+
+	if ( ! empty( $context['object'] ) ) {
+		$meta['profile:first_name'] = $context['object']->get( 'first_name' );
+		$meta['profile:last_name'] = $context['object']->get( 'last_name' );
+	}
 
 	return $meta;
 }


### PR DESCRIPTION
WordPress's query conditionals are a bit weird in that `is_author()` will return true even when querying for a non-existant author. 

This guards against fatals when viewing /author/non-existant-user/ links by checking to make sure the queried object exists before accessing it.