### PR TITLE
Removed depreceated xmlns attribute

### DIFF
--- a/inc/opengraph-namespace.php
+++ b/inc/opengraph-namespace.php
@@ -25,7 +25,7 @@ function bootstrap() {
  * @return string
  */
 function add_xmlns( string $xmlns ) : string {
-	return $xmlns . ' xmlns:og="http://ogp.me/ns#"';
+	return $xmlns . prefix="og: http://ogp.me/ns#"';
 }
 
 /**


### PR DESCRIPTION
xmlns is depreceated. See https://stackoverflow.com/questions/23339725/w3c-validator-shows-error-for-facebook-open-graph

Related https://github.com/humanmade/standard-chartered/issues/12657